### PR TITLE
Update co2-monitor to support AIRCO2NTROL COACH

### DIFF
--- a/main.js
+++ b/main.js
@@ -71,7 +71,7 @@ function CO2Accessory(log, config) {
   this.temperatureService = new Service.TemperatureSensor(this.name);
 
   this.co2monitor.on("temp", temp => {
-    that.log(that.name, "Temperatue (C):", temp);
+    that.log(that.name, "Temperature (C):", temp);
     that.temperature = temp;
     that.temperatureService.setCharacteristic(Characteristic.CurrentTemperature, Number.parseFloat(temp));
   });

--- a/main.js
+++ b/main.js
@@ -81,12 +81,10 @@ function CO2Accessory(log, config) {
     .on("get", this.getCurrentTemperature.bind(this));
 
   // Connection
-  this.co2monitor.on("connected", device => {
-    monitor.startTransfer();
+  this.co2monitor.connect(() => {
     that.log(that.name, "Connected, recieving data…");
+    monitor.transfer();
   });
-
-  this.co2monitor.connect();
 }
 
 CO2Accessory.prototype.getLevel = function(callback) {

--- a/main.js
+++ b/main.js
@@ -80,6 +80,19 @@ function CO2Accessory(log, config) {
     .getCharacteristic(Characteristic.CurrentTemperature)
     .on("get", this.getCurrentTemperature.bind(this));
 
+  // Set up Relative Humidity Service
+  this.humidityService = new Service.HumiditySensor(this.name);
+
+  this.co2monitor.on("hum", humidity => {
+    that.log(that.name, "Humidity (%):", humidity);
+    that.humidity = humidity;
+    that.humidityService.setCharacteristic(Characteristic.CurrentRelativeHumidity, Number.parseFloat(humidity));
+  });
+
+  this.humidityService
+    .getCharacteristic(Characteristic.CurrentRelativeHumidity)
+    .on("get", this.getCurrentRelativeHumidity.bind(this));
+
   // Connection
   this.co2monitor.connect(() => {
     that.log(that.name, "Connected, recieving data…");
@@ -120,6 +133,14 @@ CO2Accessory.prototype.getCurrentTemperature = function(callback) {
     return;
   }
   callback(null, new Number(this.temperature));
+};
+
+CO2Accessory.prototype.getCurrentRelativeHumidity = function(callback) {
+  if (this.humidity == null || this.humidity == undefined) {
+    callback(null, null);
+    return;
+  }
+  callback(null, new Number(this.humidity));
 };
 
 CO2Accessory.prototype.getServices = function() {

--- a/main.js
+++ b/main.js
@@ -1,6 +1,6 @@
 var Service, Characteristic;
 
-const Co2Monitor = require("co2-monitor");
+const Co2Monitor = require("@jaller94/node-co2-monitor");
 let co2Monitor = new Co2Monitor();
 
 module.exports = function(homebridge) {
@@ -31,17 +31,17 @@ function CO2Accessory(log, config) {
   this.co2monitor.on("co2", co2 => {
     that.log(that.name, "CO2 (ppm):", co2);
     if (!that.co2_peak || co2 > that.co2_peak) {
-      that.log(that.name, "CO2 Peak (ppm):", co2);        
+      that.log(that.name, "CO2 Peak (ppm):", co2);
       that.co2_peak = co2;
-      that.co2service.setCharacteristic(Characteristic.CarbonDioxidePeakLevel, co2);          
+      that.co2service.setCharacteristic(Characteristic.CarbonDioxidePeakLevel, co2);
     }
     that.co2 = co2;
-    
+
     var result = that.co2 > that.co2_warning_level
                     ? Characteristic.CarbonDioxideDetected.CO2_LEVELS_ABNORMAL
                     : Characteristic.CarbonDioxideDetected.CO2_LEVELS_NORMAL;
 
-    that.co2service.setCharacteristic(Characteristic.CarbonDioxideLevel, co2);    
+    that.co2service.setCharacteristic(Characteristic.CarbonDioxideLevel, co2);
     that.co2service.setCharacteristic(Characteristic.CarbonDioxideDetected, result);
   });
 

--- a/main.js
+++ b/main.js
@@ -26,7 +26,7 @@ function CO2Accessory(log, config) {
   // Set up CO2
   let monitor = co2Monitor;
   this.co2monitor = monitor;
-  this.co2service = new Service.CarbonDioxideSensor(this.name);
+  this.co2service = new Service.CarbonDioxideSensor("CO2 Sensor");
 
   this.co2monitor.on("co2", co2 => {
     that.log(that.name, "CO2 (ppm):", co2);
@@ -68,7 +68,7 @@ function CO2Accessory(log, config) {
     .on("get", this.getPeakLevel.bind(this));
 
   // Set up Temperature Service
-  this.temperatureService = new Service.TemperatureSensor(this.name);
+  this.temperatureService = new Service.TemperatureSensor("Temperature Sensor");
 
   this.co2monitor.on("temp", temp => {
     that.log(that.name, "Temperature (C):", temp);
@@ -81,7 +81,7 @@ function CO2Accessory(log, config) {
     .on("get", this.getCurrentTemperature.bind(this));
 
   // Set up Relative Humidity Service
-  this.humidityService = new Service.HumiditySensor(this.name);
+  this.humidityService = new Service.HumiditySensor("Humidity Sensor");
 
   this.co2monitor.on("hum", humidity => {
     that.log(that.name, "Humidity (%):", humidity);

--- a/main.js
+++ b/main.js
@@ -144,5 +144,5 @@ CO2Accessory.prototype.getCurrentRelativeHumidity = function(callback) {
 };
 
 CO2Accessory.prototype.getServices = function() {
-  return [this.co2service, this.temperatureService, this.informationService];
+  return [this.co2service, this.temperatureService, this.humidityService, this.informationService];
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,93 @@
+{
+    "name": "homebridge-aircontrol-mini",
+    "version": "0.0.5",
+    "lockfileVersion": 2,
+    "requires": true,
+    "packages": {
+        "": {
+            "name": "homebridge-aircontrol-mini",
+            "version": "0.0.5",
+            "license": "MIT",
+            "dependencies": {
+                "@jaller94/node-co2-monitor": "^0.3.4"
+            },
+            "engines": {
+                "homebridge": ">=0.2.0",
+                "node": ">=0.12.0"
+            }
+        },
+        "node_modules/@jaller94/node-co2-monitor": {
+            "version": "0.3.4",
+            "resolved": "https://registry.npmjs.org/@jaller94/node-co2-monitor/-/node-co2-monitor-0.3.4.tgz",
+            "integrity": "sha512-Or9ETKOL6Zzq233jwR7d2RjZXeg0iBP8sG4c14fw2sZyIx6u4vOnfkkbe0/s91wjv4C2/tfxffLCFcF1p9h/yA==",
+            "os": [
+                "linux",
+                "win32",
+                "darwin"
+            ],
+            "dependencies": {
+                "usb": "^1.6.5"
+            },
+            "engines": {
+                "node": ">=6.0"
+            }
+        },
+        "node_modules/node-addon-api": {
+            "version": "4.3.0",
+            "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-4.3.0.tgz",
+            "integrity": "sha512-73sE9+3UaLYYFmDsFZnqCInzPyh3MqIwZO9cw58yIqAZhONrrabrYyYe3TuIqtIiOuTXVhsGau8hcrhhwSsDIQ=="
+        },
+        "node_modules/node-gyp-build": {
+            "version": "4.5.0",
+            "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.5.0.tgz",
+            "integrity": "sha512-2iGbaQBV+ITgCz76ZEjmhUKAKVf7xfY1sRl4UiKQspfZMH2h06SyhNsnSVy50cwkFQDGLyif6m/6uFXHkOZ6rg==",
+            "bin": {
+                "node-gyp-build": "bin.js",
+                "node-gyp-build-optional": "optional.js",
+                "node-gyp-build-test": "build-test.js"
+            }
+        },
+        "node_modules/usb": {
+            "version": "1.9.2",
+            "resolved": "https://registry.npmjs.org/usb/-/usb-1.9.2.tgz",
+            "integrity": "sha512-dryNz030LWBPAf6gj8vyq0Iev3vPbCLHCT8dBw3gQRXRzVNsIdeuU+VjPp3ksmSPkeMAl1k+kQ14Ij0QHyeiAg==",
+            "hasInstallScript": true,
+            "dependencies": {
+                "node-addon-api": "^4.2.0",
+                "node-gyp-build": "^4.3.0"
+            },
+            "engines": {
+                "node": ">=10.16.0"
+            }
+        }
+    },
+    "dependencies": {
+        "@jaller94/node-co2-monitor": {
+            "version": "0.3.4",
+            "resolved": "https://registry.npmjs.org/@jaller94/node-co2-monitor/-/node-co2-monitor-0.3.4.tgz",
+            "integrity": "sha512-Or9ETKOL6Zzq233jwR7d2RjZXeg0iBP8sG4c14fw2sZyIx6u4vOnfkkbe0/s91wjv4C2/tfxffLCFcF1p9h/yA==",
+            "requires": {
+                "usb": "^1.6.5"
+            }
+        },
+        "node-addon-api": {
+            "version": "4.3.0",
+            "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-4.3.0.tgz",
+            "integrity": "sha512-73sE9+3UaLYYFmDsFZnqCInzPyh3MqIwZO9cw58yIqAZhONrrabrYyYe3TuIqtIiOuTXVhsGau8hcrhhwSsDIQ=="
+        },
+        "node-gyp-build": {
+            "version": "4.5.0",
+            "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.5.0.tgz",
+            "integrity": "sha512-2iGbaQBV+ITgCz76ZEjmhUKAKVf7xfY1sRl4UiKQspfZMH2h06SyhNsnSVy50cwkFQDGLyif6m/6uFXHkOZ6rg=="
+        },
+        "usb": {
+            "version": "1.9.2",
+            "resolved": "https://registry.npmjs.org/usb/-/usb-1.9.2.tgz",
+            "integrity": "sha512-dryNz030LWBPAf6gj8vyq0Iev3vPbCLHCT8dBw3gQRXRzVNsIdeuU+VjPp3ksmSPkeMAl1k+kQ14Ij0QHyeiAg==",
+            "requires": {
+                "node-addon-api": "^4.2.0",
+                "node-gyp-build": "^4.3.0"
+            }
+        }
+    }
+}

--- a/package.json
+++ b/package.json
@@ -34,6 +34,6 @@
     },
     "homepage": "https://github.com/toto/homebridge-aircontrol-mini#readme",
     "dependencies": {
-        "co2-monitor": "^2.0.0"
+        "@jaller94/node-co2-monitor": "^0.3.4"
     }
 }


### PR DESCRIPTION
Hey there,

I updated the co2-monitor package [with a fork](https://gitlab.com/jaller94/node-co2-monitor) which supports both the older model and the newer "coach" one.

I don't have the older monitor for trying it out, so it would be great if someone could test it out.

Hope that's useful for others as well.

Cheers.